### PR TITLE
Wanted: A way to replace attr values as they are recieved if they match a key

### DIFF
--- a/lib/gorillib/receiver.rb
+++ b/lib/gorillib/receiver.rb
@@ -88,7 +88,6 @@ module Receiver
   RECEIVER_BODIES[NilClass] = %q{ raise ArgumentError, "This field must be nil, but {#{v}} was given" unless (v.nil?) ; nil }
   RECEIVER_BODIES[Object]   = %q{ v } # accept and love the object just as it is
 
-  # add to boolean (v.to_s.strip != "false") || (v.to_s.strip =~ /^0[\.0]*$/)
   #
   # Give each base class a receive method
   #

--- a/lib/gorillib/receiver.rb
+++ b/lib/gorillib/receiver.rb
@@ -84,10 +84,11 @@ module Receiver
   RECEIVER_BODIES[Date]     = %q{ v.nil?   ? nil : Date.parse(v.to_s)     rescue nil }
   RECEIVER_BODIES[Array]    = %q{ case when v.nil? then nil when v.blank? then [] else Array(v) end }
   RECEIVER_BODIES[Hash]     = %q{ case when v.nil? then nil when v.blank? then {} else v end }
-  RECEIVER_BODIES[Boolean]  = %q{ case when v.nil? then nil when v.to_s.strip.blank? then false else v.to_s.strip != "false" end }
+  RECEIVER_BODIES[Boolean]  = %q{ case when v.nil? then nil when v.to_s.strip.blank? then false when v.to_s.strip =~ /^0[\.0]*$/ then false else v.to_s.strip != "false" end }
   RECEIVER_BODIES[NilClass] = %q{ raise ArgumentError, "This field must be nil, but {#{v}} was given" unless (v.nil?) ; nil }
   RECEIVER_BODIES[Object]   = %q{ v } # accept and love the object just as it is
 
+  # add to boolean (v.to_s.strip != "false") || (v.to_s.strip =~ /^0[\.0]*$/)
   #
   # Give each base class a receive method
   #

--- a/lib/gorillib/receiver.rb
+++ b/lib/gorillib/receiver.rb
@@ -125,6 +125,7 @@ module Receiver
       _receive_attr attr, val
     end
     impose_defaults!(hsh)
+    replace_options!(hsh)
     run_after_receivers(hsh)
     self
   end
@@ -148,6 +149,24 @@ protected
     self.class.receiver_defaults.each do |attr, val|
       next if attr_set?(attr)
       self.instance_variable_set "@#{attr}", val
+    end
+  end
+
+  # class Foo
+  #   include Receiver
+  #   include Receiver::ActsAsHash
+  #   rcvr_accessor :attribute, String, :default => 'okay' :replace => { 'bad' => 'good' }
+  # end
+  #
+  # f = Foo.receive({:attribute => 'bad'})
+  # => #<Foo:0x10156c820 @attribute="good">
+
+  def replace_options!(hsh)
+    self.receiver_attrs.each do |attr, info|
+      val = self.instance_variable_get("@#{attr}")
+      if info[:replace] and info[:replace].has_key? val
+        self.instance_variable_set "@#{attr}", info[:replace][val]
+      end
     end
   end
 


### PR DESCRIPTION
Functionality added:

class Foo
  include Receiver
  include Receiver::ActsAsHash

  rcvr_accessor :name, String, :replace => { 'Flip' => 'Travis' }

end

f = Foo.receive({ :name => 'Flip'})
=> #<Foo:0x1014acf48 @name="Travis">

Works for Strings, Integers, and Hashes. I need the Boolean coverage as well or my currently raised gorillib issue to be closed. Could work for Arrays if you sorted, haven't confirmed.
